### PR TITLE
Use per-media aspect ratios for product gallery

### DIFF
--- a/assets/media-gallery.css
+++ b/assets/media-gallery.css
@@ -315,3 +315,16 @@ product-model[loaded] .media-poster {
     flex: 0 0 50%;
   }
 }
+
+/* Per-image aspect ratio support (inline --media-ratio / --thumb-ratio) */
+.media[style*="--media-ratio"],
+.media-thumbs__btn[style*="--thumb-ratio"] {
+  /* The layout already uses padding-top with absolute children.
+     No change needed for modern browsers, this is a harmless hint. */
+  aspect-ratio: auto;
+}
+
+/* Ensure contain-fit images never stretch outside their box */
+.product-image.img-fit--contain {
+  max-width: 100%;
+}

--- a/snippets/media-gallery.liquid
+++ b/snippets/media-gallery.liquid
@@ -244,7 +244,8 @@
               endif
             -%}
             <li class="media-thumbs__item{% if section.settings.hide_variants and variant_images contains media.src %} media-thumbs__item--variant{% endif %}" data-media-id="{{ media.id }}">
-              <button class="media-thumbs__btn media relative w-full{% if settings.blend_product_images %} image-blend{% endif %}{% if active and section.settings.enable_media_grouping == false %} is-active{% endif %}"{% if active %} aria-current="true"{% endif %} aria-controls="gallery-viewer"{% if section.settings.thumb_ratio != 'natural' %} style="padding-top: {{ 1 | divided_by: thumb_ratio | times: 100 }}%;"{% endif %}>
+              {%- assign this_thumb_ratio = media.preview_image.aspect_ratio | default: 1 -%}
+              <button class="media-thumbs__btn media relative w-full{% if settings.blend_product_images %} image-blend{% endif %}{% if active and section.settings.enable_media_grouping == false %} is-active{% endif %}"{% if active %} aria-current="true"{% endif %} aria-controls="gallery-viewer"{% if section.settings.thumb_ratio != 'natural' %} style="--thumb-ratio: {{ this_thumb_ratio }}; padding-top: {{ 1 | divided_by: this_thumb_ratio | times: 100 }}%;"{% endif %}>
                 <span class="visually-hidden">
                   {%- if media.media_type == 'image' -%}
                     {{- 'products.product.media.load_image' | t: index: image_index -}}

--- a/snippets/product-media.liquid
+++ b/snippets/product-media.liquid
@@ -114,7 +114,8 @@
 {%- endcapture -%}
 
 {%- if media.media_type == 'image' -%}
-  <div class="media relative{% if settings.blend_product_images %} image-blend{% endif %}" style="padding-top: {{ 1 | divided_by: media_ratio | times: 100 }}%;">
+  {%- assign this_media_ratio = media.preview_image.aspect_ratio | default: 1 -%}
+  <div class="media relative{% if settings.blend_product_images %} image-blend{% endif %}" style="--media-ratio: {{ this_media_ratio }}; padding-top: {{ 1 | divided_by: this_media_ratio | times: 100 }}%;">
     {%- if enable_zoom -%}
       {%- liquid
         if media_crop != "none"
@@ -154,9 +155,11 @@
   </div>
 {%- else -%}
   {%- if media.media_type == 'model' -%}
-    <product-model class="block relative no-js-hidden" style="padding-top: {{ 1 | divided_by: media_ratio | times: 100 }}%" data-media-id="{{ media.id }}">
+    {%- assign this_media_ratio = media.preview_image.aspect_ratio | default: 1 -%}
+    <product-model class="block relative no-js-hidden" style="--media-ratio: {{ this_media_ratio }}; padding-top: {{ 1 | divided_by: this_media_ratio | times: 100 }}%" data-media-id="{{ media.id }}">
   {%- else -%}
-    <deferred-media class="block relative no-js-hidden" style="padding-top: {{ 1 | divided_by: media_ratio | times: 100 }}%" data-media-id="{{ media.id }}">
+    {%- assign this_media_ratio = media.preview_image.aspect_ratio | default: 1 -%}
+    <deferred-media class="block relative no-js-hidden" style="--media-ratio: {{ this_media_ratio }}; padding-top: {{ 1 | divided_by: this_media_ratio | times: 100 }}%" data-media-id="{{ media.id }}">
   {%- endif -%}
 
   <button type="button" class="media-poster absolute top-0 left-0 flex justify-center items-center w-full h-full js-load-media">


### PR DESCRIPTION
## Summary
- compute aspect ratios individually for each product media and thumbnail
- add CSS hint and containment rule to ensure proportional media

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd1a3a3748326b11381de06e93a35