### PR TITLE
Fix product image scaling for natural aspect ratio

### DIFF
--- a/snippets/media-gallery.liquid
+++ b/snippets/media-gallery.liquid
@@ -98,6 +98,12 @@
           assign lazy_load = true
           assign select_first_image = false
 
+          # Use individual aspect ratios when natural is selected to avoid empty space
+          assign current_media_ratio = media_ratio
+          if section.settings.media_ratio == 'natural'
+            assign current_media_ratio = media.preview_image.aspect_ratio
+          endif
+
           if featured_media == null and forloop.index == 1
             assign lazy_load = false
             assign select_first_image = true
@@ -117,7 +123,7 @@
           {%- endif -%}
           {% render 'product-media',
             media: media,
-            media_ratio: media_ratio,
+            media_ratio: current_media_ratio,
             media_crop: media_crop,
             loop: section.settings.enable_video_looping,
             lazy_load: lazy_load,


### PR DESCRIPTION
## Summary
- adjust product media gallery to use each image's natural aspect ratio
- prevent empty space around product images and keep gallery responsive

## Testing
- `node tests/media-gallery.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bfdab6cfb88326aa93f8652d0059d5