### PR TITLE
Fix product image aspect ratio handling

### DIFF
--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -52,24 +52,6 @@
   assign first_3d_model = product.media | where: 'media_type', 'model' | first
   assign media_ratio = section.settings.media_ratio
   assign thumb_ratio = section.settings.thumb_ratio
-
-  if media_ratio == 'natural'
-    assign media_ratio = 99
-    for media in product.media
-      if media.preview_image.aspect_ratio < media_ratio
-        assign media_ratio = media.preview_image.aspect_ratio
-      endif
-    endfor
-  endif
-
-  if thumb_ratio == 'natural'
-    assign thumb_ratio = 99
-    for media in product.media
-      if media.preview_image.aspect_ratio < thumb_ratio
-        assign thumb_ratio = media.preview_image.aspect_ratio
-      endif
-    endfor
-  endif
 -%}
 
 {%- style -%}

--- a/snippets/product-media.liquid
+++ b/snippets/product-media.liquid
@@ -1,7 +1,7 @@
 {%- comment -%}
   Parameters:
   - media {Object} - Media object.
-  - media_ratio {Number} - Media aspect ratio.
+  - media_ratio {Number\|String} - Media aspect ratio or "natural" to use each image's ratio.
   - media_crop {String} - If media should crop to fill available space (Options: none, top, center)
   - loop {Boolean} - Enable video looping.
   - lazy_load {Boolean} - Lazy load the media.
@@ -106,19 +106,23 @@
       when 'large'
         assign zoom_level = 1500
     endcase
+    endif
+  assign current_media_ratio = media_ratio
+  if media_ratio == 'natural'
+    assign current_media_ratio = media.preview_image.aspect_ratio
   endif
--%}
+  -%}
 
 {%- capture sizes -%}
   {%- render 'sizes-attribute', min: 'page', sm: 'page', md: 'calc(50vw - 64px)', lg: sizes_lg, xl: sizes_xl, max: sizes_max -%}
 {%- endcapture -%}
 
 {%- if media.media_type == 'image' -%}
-  <div class="media relative{% if settings.blend_product_images %} image-blend{% endif %}" style="padding-top: {{ 1 | divided_by: media_ratio | times: 100 }}%;">
+  <div class="media relative{% if settings.blend_product_images %} image-blend{% endif %}" style="padding-top: {{ 1 | divided_by: current_media_ratio | times: 100 }}%;">
     {%- if enable_zoom -%}
       {%- liquid
         if media_crop != "none"
-          assign height = zoom_level | divided_by: media_ratio
+          assign height = zoom_level | divided_by: current_media_ratio
           assign image_url = media.preview_image | image_url: width: zoom_level, height: height, crop: media_crop
         else
           assign image_url = media.preview_image | image_url: width: zoom_level
@@ -144,8 +148,8 @@
     {%- if enable_zoom -%}
         <img class="zoom-image{% if media_crop == "none" %} zoom-image--contain top-0{% endif %} absolute left-0 right-0 pointer-events-none js-zoom-image no-js-hidden"
              alt="{{ media.alt | escape }}"
-             src="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20{{ zoom_level }}%20{{ zoom_level | divided_by: media_ratio }}'%3E%3C/svg%3E" loading="lazy"
-             data-src="{{ image_url }}" width="{{ zoom_level }}" height="{{ zoom_level | divided_by: media_ratio }}"
+             src="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20{{ zoom_level }}%20{{ zoom_level | divided_by: current_media_ratio }}'%3E%3C/svg%3E" loading="lazy"
+             data-src="{{ image_url }}" width="{{ zoom_level }}" height="{{ zoom_level | divided_by: current_media_ratio }}"
              data-original-width="{{ media.preview_image.width }}" data-original-height="{{ media.preview_image.height }}">
       </a>
     {%- else -%}
@@ -154,9 +158,9 @@
   </div>
 {%- else -%}
   {%- if media.media_type == 'model' -%}
-    <product-model class="block relative no-js-hidden" style="padding-top: {{ 1 | divided_by: media_ratio | times: 100 }}%" data-media-id="{{ media.id }}">
+    <product-model class="block relative no-js-hidden" style="padding-top: {{ 1 | divided_by: current_media_ratio | times: 100 }}%" data-media-id="{{ media.id }}">
   {%- else -%}
-    <deferred-media class="block relative no-js-hidden" style="padding-top: {{ 1 | divided_by: media_ratio | times: 100 }}%" data-media-id="{{ media.id }}">
+    <deferred-media class="block relative no-js-hidden" style="padding-top: {{ 1 | divided_by: current_media_ratio | times: 100 }}%" data-media-id="{{ media.id }}">
   {%- endif -%}
 
   <button type="button" class="media-poster absolute top-0 left-0 flex justify-center items-center w-full h-full js-load-media">


### PR DESCRIPTION
## Summary
- use product's configured media ratio values directly
- compute individual media aspect ratios to eliminate whitespace in gallery

## Testing
- `node tests/media-gallery.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bfdab6cfb88326aa93f8652d0059d5