### PR TITLE
Fix product image scaling for natural aspect ratios

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -1877,30 +1877,18 @@ window.addEventListener('pageshow', (evt) => {
 });
 
 // Init mobile-only scrolling where needed
-if (window.OverlayScrollbarsGlobal) {
-  const initMobileScrollbars = () => {
-    document.querySelectorAll('.slider--mobile').forEach((slider) => {
-      window.OverlayScrollbarsGlobal.OverlayScrollbars({
-        target: slider.parentElement,
-        elements: {
-          viewport: slider
-        }
-      }, {});
-    });
-  };
+  if (window.OverlayScrollbarsGlobal) {
+    const initMobileScrollbars = () => {
+      document.querySelectorAll('.slider--mobile').forEach((slider) => {
+        window.OverlayScrollbarsGlobal.OverlayScrollbars({
+          target: slider.parentElement,
+          elements: {
+            viewport: slider
+          }
+        }, {});
+      });
+    };
 
-  initMobileScrollbars();
-  document.addEventListener('shopify:section:load', initMobileScrollbars);
-}
-
-// Ensure product image sizing overrides inline aspect ratios
-document.addEventListener('DOMContentLoaded', () => {
-  const mainImage = document.querySelector('.media-gallery__viewer img.product-image');
-  if (mainImage) {
-    mainImage.style.aspectRatio = 'unset';
-    mainImage.style.width = '100%';
-    mainImage.style.height = 'auto';
-    mainImage.style.maxHeight = '600px';
-    mainImage.style.objectFit = 'contain';
+    initMobileScrollbars();
+    document.addEventListener('shopify:section:load', initMobileScrollbars);
   }
-}, { once: true });

--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -48,15 +48,6 @@
   assign first_3d_model = product.media | where: 'media_type', 'model' | first
   assign media_ratio = section.settings.media_ratio
 
-  if media_ratio == 'natural'
-    assign media_ratio = 99
-    for media in product.media
-      if media.preview_image.aspect_ratio < media_ratio
-        assign media_ratio = media.preview_image.aspect_ratio
-      endif
-    endfor
-  endif
-
   assign color_scheme = section.settings.color_scheme
   assign bg_color = false
 

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -53,15 +53,6 @@
   assign media_ratio = section.settings.media_ratio
   assign thumb_ratio = section.settings.thumb_ratio
 
-  if media_ratio == 'natural'
-    assign media_ratio = 99
-    for media in product.media
-      if media.preview_image.aspect_ratio < media_ratio
-        assign media_ratio = media.preview_image.aspect_ratio
-      endif
-    endfor
-  endif
-
   if thumb_ratio == 'natural'
     assign thumb_ratio = 99
     for media in product.media

--- a/snippets/media-gallery.liquid
+++ b/snippets/media-gallery.liquid
@@ -110,6 +110,11 @@
           if forloop.index == 1
             assign lazy_load = false
           endif
+
+          assign current_ratio = media_ratio
+          if media_ratio == 'natural'
+            assign current_ratio = media.preview_image.aspect_ratio
+          endif
         -%}
         <li class="media-viewer__item{% if media.id == featured_media.id or select_first_image %} is-current-variant{% endif %}{% if section.settings.hide_variants and variant_images contains media.src %} media-viewer__item--variant{% endif %}{% if section.settings.media_layout == 'stacked' and media.id == featured_media.id %}{% if underline_active and section.settings.enable_media_grouping == false %} is-active{% endif %}{% endif %}{% if media_count == 1 %} media-viewer__item--single{% endif %}" data-media-id="{{ media.id }}" data-media-type="{{ media.media_type }}">
           {%- if enable_zoom and lightbox_enabled and media.media_type == 'image' -%}
@@ -117,7 +122,7 @@
           {%- endif -%}
           {% render 'product-media',
             media: media,
-            media_ratio: media_ratio,
+            media_ratio: current_ratio,
             media_crop: media_crop,
             loop: section.settings.enable_video_looping,
             lazy_load: lazy_load,


### PR DESCRIPTION
## Summary
- Use each media's aspect ratio to size product gallery items and remove empty gaps
- Remove forced product image sizing script
- Simplify product sections to rely on settings for aspect ratios

## Testing
- `node tests/media-gallery.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bfdab6cfb88326aa93f8652d0059d5