### PR TITLE
Center product thumbnails and fit media container to images

### DIFF
--- a/assets/media-gallery.css
+++ b/assets/media-gallery.css
@@ -44,6 +44,7 @@
   overflow-x: scroll;
   scroll-snap-type: x mandatory;
   scrollbar-width: none;
+  justify-content: center;
 }
 .media-viewer::-webkit-scrollbar,
 .media-thumbs::-webkit-scrollbar {

--- a/assets/media-gallery.js
+++ b/assets/media-gallery.js
@@ -392,6 +392,8 @@ if (!customElements.get('media-gallery')) {
       if (this.thumbs && this.currentThumb) {
         this.checkThumbVisibilty(this.currentThumb);
       }
+
+      this.viewer.style.height = `${this.currentItem.offsetHeight}px`;
     }
 
     /**
@@ -410,6 +412,8 @@ if (!customElements.get('media-gallery')) {
       window.pauseAllMedia(this);
       this.currentItem = mediaItem;
       this.currentIndex = this.visibleItems.indexOf(this.currentItem);
+
+      this.viewer.style.height = `${this.currentItem.offsetHeight}px`;
 
       if (this.dataset.layout === 'stacked' && theme.mediaMatches.md) {
         // Update the active class and scroll to the active media

--- a/snippets/product-media.liquid
+++ b/snippets/product-media.liquid
@@ -107,6 +107,8 @@
         assign zoom_level = 1500
     endcase
   endif
+
+  assign item_ratio = media.preview_image.aspect_ratio | default: 1
 -%}
 
 {%- capture sizes -%}
@@ -114,11 +116,11 @@
 {%- endcapture -%}
 
 {%- if media.media_type == 'image' -%}
-  <div class="media relative{% if settings.blend_product_images %} image-blend{% endif %}" style="padding-top: {{ 1 | divided_by: media_ratio | times: 100 }}%;">
+  <div class="media relative{% if settings.blend_product_images %} image-blend{% endif %}" style="padding-top: {{ 1 | divided_by: item_ratio | times: 100 }}%;">
     {%- if enable_zoom -%}
       {%- liquid
         if media_crop != "none"
-          assign height = zoom_level | divided_by: media_ratio
+          assign height = zoom_level | divided_by: item_ratio
           assign image_url = media.preview_image | image_url: width: zoom_level, height: height, crop: media_crop
         else
           assign image_url = media.preview_image | image_url: width: zoom_level
@@ -144,8 +146,8 @@
     {%- if enable_zoom -%}
         <img class="zoom-image{% if media_crop == "none" %} zoom-image--contain top-0{% endif %} absolute left-0 right-0 pointer-events-none js-zoom-image no-js-hidden"
              alt="{{ media.alt | escape }}"
-             src="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20{{ zoom_level }}%20{{ zoom_level | divided_by: media_ratio }}'%3E%3C/svg%3E" loading="lazy"
-             data-src="{{ image_url }}" width="{{ zoom_level }}" height="{{ zoom_level | divided_by: media_ratio }}"
+             src="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20{{ zoom_level }}%20{{ zoom_level | divided_by: item_ratio }}'%3E%3C/svg%3E" loading="lazy"
+             data-src="{{ image_url }}" width="{{ zoom_level }}" height="{{ zoom_level | divided_by: item_ratio }}"
              data-original-width="{{ media.preview_image.width }}" data-original-height="{{ media.preview_image.height }}">
       </a>
     {%- else -%}
@@ -154,9 +156,9 @@
   </div>
 {%- else -%}
   {%- if media.media_type == 'model' -%}
-    <product-model class="block relative no-js-hidden" style="padding-top: {{ 1 | divided_by: media_ratio | times: 100 }}%" data-media-id="{{ media.id }}">
+    <product-model class="block relative no-js-hidden" style="padding-top: {{ 1 | divided_by: item_ratio | times: 100 }}%" data-media-id="{{ media.id }}">
   {%- else -%}
-    <deferred-media class="block relative no-js-hidden" style="padding-top: {{ 1 | divided_by: media_ratio | times: 100 }}%" data-media-id="{{ media.id }}">
+    <deferred-media class="block relative no-js-hidden" style="padding-top: {{ 1 | divided_by: item_ratio | times: 100 }}%" data-media-id="{{ media.id }}">
   {%- endif -%}
 
   <button type="button" class="media-poster absolute top-0 left-0 flex justify-center items-center w-full h-full js-load-media">


### PR DESCRIPTION
## Summary
- Center product thumbnails below active media
- Resize product media container to match each image's aspect ratio
- Adjust gallery height dynamically as media changes

## Testing
- `node tests/media-gallery.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bfdddeb218832691a43c951bdd6bce