### PR TITLE
Refine product media gallery layout

### DIFF
--- a/assets/media-gallery.css
+++ b/assets/media-gallery.css
@@ -223,16 +223,17 @@ product-model[loaded] .media-poster {
   }
   .product-image.img-fit--contain,
   .zoom-image--contain {
+    top: 50%;
     left: 50%;
     width: auto;
     height: 100%;
-    transform: translatex(-50%);
+    transform: translate(-50%, -50%);
   }
   [dir=rtl] .product-image.img-fit--contain,
   [dir=rtl] .zoom-image--contain {
     right: 50%;
     left: auto;
-    transform: translatex(50%);
+    transform: translate(50%, -50%);
   }
   .media--zoom {
     cursor: zoom-in;

--- a/snippets/media-gallery.liquid
+++ b/snippets/media-gallery.liquid
@@ -117,8 +117,6 @@
           {%- endif -%}
           {% render 'product-media',
             media: media,
-            media_ratio: media_ratio,
-            media_crop: media_crop,
             loop: section.settings.enable_video_looping,
             lazy_load: lazy_load,
             enable_zoom: enable_zoom,
@@ -244,7 +242,7 @@
               endif
             -%}
             <li class="media-thumbs__item{% if section.settings.hide_variants and variant_images contains media.src %} media-thumbs__item--variant{% endif %}" data-media-id="{{ media.id }}">
-              <button class="media-thumbs__btn media relative w-full{% if settings.blend_product_images %} image-blend{% endif %}{% if active and section.settings.enable_media_grouping == false %} is-active{% endif %}"{% if active %} aria-current="true"{% endif %} aria-controls="gallery-viewer"{% if section.settings.thumb_ratio != 'natural' %} style="padding-top: {{ 1 | divided_by: thumb_ratio | times: 100 }}%;"{% endif %}>
+              <button class="media-thumbs__btn media relative w-full{% if settings.blend_product_images %} image-blend{% endif %}{% if active and section.settings.enable_media_grouping == false %} is-active{% endif %}"{% if active %} aria-current="true"{% endif %} aria-controls="gallery-viewer" style="padding-top: {{ 1 | divided_by: media.preview_image.aspect_ratio | times: 100 }}%;">
                 <span class="visually-hidden">
                   {%- if media.media_type == 'image' -%}
                     {{- 'products.product.media.load_image' | t: index: image_index -}}
@@ -267,17 +265,7 @@
 
                 {%- liquid
                   assign src_width = 80
-                  if section.settings.thumb_ratio != 'natural'
-                    if thumb_crop == 'top'
-                      assign img_class = 'img-fit object-top w-full'
-                      assign src_width = 150
-                    elsif thumb_crop == 'center'
-                      assign img_class = 'img-fit w-full'
-                      assign src_width = 150
-                    else
-                      assign img_class = 'img-fit img-fit--contain w-full'
-                    endif
-                  endif
+                  assign img_class = 'img-fit img-fit--contain w-full'
                 -%}
 
                 {% render 'image',

--- a/snippets/product-media.liquid
+++ b/snippets/product-media.liquid
@@ -1,8 +1,8 @@
 {%- comment -%}
   Parameters:
   - media {Object} - Media object.
-  - media_ratio {Number} - Media aspect ratio.
-  - media_crop {String} - If media should crop to fill available space (Options: none, top, center)
+  - media_ratio {Number} - Media aspect ratio (optional, defaults to natural).
+  - media_crop {String} - If media should crop to fill available space (unused, defaults to none)
   - loop {Boolean} - Enable video looping.
   - lazy_load {Boolean} - Lazy load the media.
   - enable_zoom {Boolean} - Whether zoom should be enabled or not
@@ -14,7 +14,7 @@
   {% render 'product-media',
     media: media,
     media_ratio: media_ratio,
-    media_crop: 'top',
+    media_crop: 'none',
     loop: section.settings.enable_video_looping,
     lazy_load: false,
     enable_zoom: true,
@@ -24,6 +24,9 @@
 {%- endcomment -%}
 
 {%- liquid
+  assign media_ratio = media.preview_image.aspect_ratio
+  assign media_crop = 'none'
+
   if featured_product
     assign widths = '536, 800, 1072, 1280'
     assign src_width = 1280
@@ -80,17 +83,7 @@
     endif
   endif
 
-  if section.settings.media_ratio != 'natural'
-    if media_crop == 'top'
-      assign img_class = 'product-image img-fit object-top w-full'
-    elsif media_crop == 'center'
-      assign img_class = 'product-image img-fit w-full'
-    else
-      assign img_class = 'product-image img-fit img-fit--contain w-full'
-    endif
-  else
-    assign img_class = 'product-image img-fit img-fit--contain w-full'
-  endif
+  assign img_class = 'product-image img-fit img-fit--contain w-full'
 
   if enable_zoom
     case zoom_level
@@ -142,7 +135,7 @@
     %}
 
     {%- if enable_zoom -%}
-        <img class="zoom-image{% if media_crop == "none" %} zoom-image--contain top-0{% endif %} absolute left-0 right-0 pointer-events-none js-zoom-image no-js-hidden"
+        <img class="zoom-image zoom-image--contain absolute left-0 right-0 pointer-events-none js-zoom-image no-js-hidden"
              alt="{{ media.alt | escape }}"
              src="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20{{ zoom_level }}%20{{ zoom_level | divided_by: media_ratio }}'%3E%3C/svg%3E" loading="lazy"
              data-src="{{ image_url }}" width="{{ zoom_level }}" height="{{ zoom_level | divided_by: media_ratio }}"


### PR DESCRIPTION
## Summary
- use natural aspect ratio and contain-fit for product media
- align contain images vertically to remove zoom whitespace
- keep thumbnails proportional and uncropped

## Testing
- `node tests/media-gallery.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bfe4cc2e6c8326b9d9ea74d508733e