### PR TITLE
Improve product media gallery layout

### DIFF
--- a/assets/media-gallery.css
+++ b/assets/media-gallery.css
@@ -208,6 +208,24 @@
   display: none;
 }
 
+.product-image.img-fit--contain,
+.zoom-image--contain {
+  top: 50%;
+  left: 50%;
+  width: auto;
+  height: auto;
+  max-width: 100%;
+  max-height: 100%;
+  transform: translate(-50%, -50%);
+}
+
+[dir=rtl] .product-image.img-fit--contain,
+[dir=rtl] .zoom-image--contain {
+  right: 50%;
+  left: auto;
+  transform: translate(50%, -50%);
+}
+
 product-model[loaded] .media-poster {
   display: none;
 }
@@ -220,19 +238,6 @@ product-model[loaded] .media-poster {
 @media (min-width: 769px) {
   .media-gallery {
     --media-gap: calc(3 * var(--space-unit));
-  }
-  .product-image.img-fit--contain,
-  .zoom-image--contain {
-    left: 50%;
-    width: auto;
-    height: 100%;
-    transform: translatex(-50%);
-  }
-  [dir=rtl] .product-image.img-fit--contain,
-  [dir=rtl] .zoom-image--contain {
-    right: 50%;
-    left: auto;
-    transform: translatex(50%);
   }
   .media--zoom {
     cursor: zoom-in;

--- a/snippets/media-gallery.liquid
+++ b/snippets/media-gallery.liquid
@@ -117,8 +117,8 @@
           {%- endif -%}
           {% render 'product-media',
             media: media,
-            media_ratio: media_ratio,
-            media_crop: media_crop,
+            media_ratio: media.preview_image.aspect_ratio,
+            media_crop: 'none',
             loop: section.settings.enable_video_looping,
             lazy_load: lazy_load,
             enable_zoom: enable_zoom,
@@ -244,7 +244,7 @@
               endif
             -%}
             <li class="media-thumbs__item{% if section.settings.hide_variants and variant_images contains media.src %} media-thumbs__item--variant{% endif %}" data-media-id="{{ media.id }}">
-              <button class="media-thumbs__btn media relative w-full{% if settings.blend_product_images %} image-blend{% endif %}{% if active and section.settings.enable_media_grouping == false %} is-active{% endif %}"{% if active %} aria-current="true"{% endif %} aria-controls="gallery-viewer"{% if section.settings.thumb_ratio != 'natural' %} style="padding-top: {{ 1 | divided_by: thumb_ratio | times: 100 }}%;"{% endif %}>
+              <button class="media-thumbs__btn media relative w-full{% if settings.blend_product_images %} image-blend{% endif %}{% if active and section.settings.enable_media_grouping == false %} is-active{% endif %}"{% if active %} aria-current="true"{% endif %} aria-controls="gallery-viewer" style="padding-top: {{ 1 | divided_by: media.preview_image.aspect_ratio | times: 100 }}%;">
                 <span class="visually-hidden">
                   {%- if media.media_type == 'image' -%}
                     {{- 'products.product.media.load_image' | t: index: image_index -}}
@@ -266,18 +266,8 @@
                 {%- endif -%}
 
                 {%- liquid
-                  assign src_width = 80
-                  if section.settings.thumb_ratio != 'natural'
-                    if thumb_crop == 'top'
-                      assign img_class = 'img-fit object-top w-full'
-                      assign src_width = 150
-                    elsif thumb_crop == 'center'
-                      assign img_class = 'img-fit w-full'
-                      assign src_width = 150
-                    else
-                      assign img_class = 'img-fit img-fit--contain w-full'
-                    endif
-                  endif
+                  assign src_width = 150
+                  assign img_class = 'img-fit img-fit--contain w-full'
                 -%}
 
                 {% render 'image',

--- a/snippets/product-media.liquid
+++ b/snippets/product-media.liquid
@@ -24,6 +24,7 @@
 {%- endcomment -%}
 
 {%- liquid
+  assign media_ratio = media_ratio | default: media.preview_image.aspect_ratio
   if featured_product
     assign widths = '536, 800, 1072, 1280'
     assign src_width = 1280


### PR DESCRIPTION
## Summary
- render product media using each item's natural aspect ratio with contain fit to avoid cropping
- center gallery media and thumbnails, keeping proportional posters for images, video and 3D models
- tweak gallery CSS so images remain centered without growing whitespace at different zoom levels

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node tests/media-gallery.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bfe4cc2e6c8326b9d9ea74d508733e