### PR TITLE
Improve product image gallery spacing and layout

### DIFF
--- a/assets/media-gallery.css
+++ b/assets/media-gallery.css
@@ -27,16 +27,16 @@
 }
 
 .media-gallery {
-  --media-gap: calc(2 * var(--space-unit));
-  --media-gutter: calc(4 * var(--space-unit));
+  --media-gap: var(--space-unit);
+  --media-gutter: 0;
 }
 .media-gallery .skip-link.btn {
   left: 16px;
 }
 
 .media-gallery__viewer {
-  border: 1px solid var(--gallery-border-color);
-  background-color: var(--gallery-bg-color);
+  border: none;
+  background-color: transparent;
 }
 
 .media-viewer,
@@ -56,7 +56,7 @@
 }
 .media-viewer__item:not(:last-child),
 .media-thumbs__item:not(:last-child) {
-  margin-inline-end: var(--media-gap);
+  margin-inline-end: 0;
 }
 
 .media-viewer__item--variant:not(:first-child),
@@ -67,6 +67,10 @@
 .media-viewer__item {
   flex: 0 0 100%;
   text-align: center;
+  padding: 0;
+}
+.media-viewer__item:not(:last-child) {
+  margin-bottom: var(--media-gap);
 }
 .media-viewer__item > deferred-media[loaded] {
   z-index: 3;
@@ -267,21 +271,21 @@ product-model[loaded] .media-poster {
   }
   .product-media--stacked .media-viewer {
     flex-wrap: wrap;
-    margin: 0 calc(var(--media-gap) * -1) calc(var(--media-gap) * -1) 0;
+    margin: 0;
   }
   .product-media--stacked .media-gallery__viewer {
     border: 0;
     background-color: transparent;
   }
   .product-media--stacked .media-viewer__item {
-    margin: 0;
-    padding: 0 var(--media-gap) var(--media-gap) 0;
+    margin: 0 0 var(--media-gap) 0;
+    padding: 0;
   }
   .product-media--stacked .media-viewer__item .media,
   .product-media--stacked .media-viewer__item deferred-media,
   .product-media--stacked .media-viewer__item product-model {
-    border: 1px solid var(--gallery-border-color);
-    background-color: var(--gallery-bg-color);
+    border: none;
+    background-color: transparent;
   }
   .product-media--stacked .zoom-image {
     display: none;
@@ -311,12 +315,12 @@ product-model[loaded] .media-poster {
 }
 @media (min-width: 1024px) {
   .media-gallery {
-    --media-gutter: calc(6 * var(--space-unit));
+    --media-gutter: 0;
   }
   .media-thumbs__item {
     flex: 0 0 80px;
   }
   .product-media--stacked .media-viewer__item:not(.media-viewer__item--single) {
-    flex: 0 0 50%;
+    flex: 0 0 100%;
   }
 }

--- a/assets/product-page.css
+++ b/assets/product-page.css
@@ -4,8 +4,8 @@
 }
 
 .product-main .product-media {
-  margin-top: calc(5 * var(--space-unit));
-  margin-bottom: calc(5 * var(--space-unit));
+  margin-top: 0;
+  margin-bottom: 0;
 }
 
 .product-details__calc .h4 {
@@ -52,8 +52,8 @@
   .product-main .product-media {
     margin-top: 0;
     margin-bottom: 0;
-    padding-top: calc(10 * var(--space-unit));
-    padding-bottom: calc(10 * var(--space-unit));
+    padding-top: 0;
+    padding-bottom: 0;
     padding-inline-end: var(--product-column-padding);
   }
   .product-main .product-info {
@@ -101,9 +101,11 @@
   :root {
     --product-column-padding: calc(12 * var(--space-unit));
   }
-  .product-main .product-media,
   .product-main .product-info {
     padding-top: calc(12 * var(--space-unit));
+  }
+  .product-main .product-media {
+    padding-top: 0;
   }
 }
 

--- a/tests/media-gallery.test.js
+++ b/tests/media-gallery.test.js
@@ -1,4 +1,6 @@
 const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
 
 function paddingPercent(aspectRatio) {
   return (1 / aspectRatio) * 100;
@@ -9,4 +11,14 @@ assert.strictEqual(paddingPercent(1), 100);
 assert.strictEqual(paddingPercent(2), 50);
 assert(Math.abs(paddingPercent(1.5) - 66.6666) < 0.0001);
 
+// Ensure CSS tweaks remove gallery borders and tighten gaps
+const css = fs.readFileSync(path.join(__dirname, '../assets/media-gallery.css'), 'utf8');
+assert(css.includes('border: none'));
+assert(css.includes('--media-gap: var(--space-unit)'));
+
+// Ensure product page media container has no extra margin
+const prodCss = fs.readFileSync(path.join(__dirname, '../assets/product-page.css'), 'utf8');
+assert(prodCss.includes('.product-main .product-media {\n  margin-top: 0;'));
+
 console.log('media-gallery tests passed');
+


### PR DESCRIPTION
## Summary
- Remove excess spacing around product media for full-width presentation
- Simplify media gallery styles and enable responsive stacked images
- Add tests validating aspect ratios and CSS changes

## Testing
- `node tests/media-gallery.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bfe9bc14788326839542b46fd5f893