### PR TITLE
Refine product gallery layout

### DIFF
--- a/assets/media-gallery.css
+++ b/assets/media-gallery.css
@@ -37,6 +37,7 @@
 .media-gallery__viewer {
   border: none;
   background-color: transparent;
+  width: 100%;
 }
 
 .media-viewer,
@@ -48,6 +49,9 @@
 .media-viewer::-webkit-scrollbar,
 .media-thumbs::-webkit-scrollbar {
   display: none;
+}
+.media-thumbs {
+  justify-content: center;
 }
 
 .media-viewer__item,
@@ -68,12 +72,22 @@
   flex: 0 0 100%;
   text-align: center;
   padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 .media-viewer__item:not(:last-child) {
   margin-bottom: var(--media-gap);
 }
 .media-viewer__item > deferred-media[loaded] {
   z-index: 3;
+}
+
+.media--cover {
+  background-color: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .media-poster__btn,
@@ -295,10 +309,10 @@ product-model[loaded] .media-poster {
     display: block;
   }
   .media--cover {
-    top: -1px;
-    right: -1px;
-    bottom: -1px;
-    left: -1px;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
     width: auto;
     height: auto;
   }
@@ -316,6 +330,18 @@ product-model[loaded] .media-poster {
 @media (min-width: 1024px) {
   .media-gallery {
     --media-gutter: 0;
+  }
+  .media-gallery__viewer,
+  .media-viewer__item,
+  .media--cover {
+    max-height: 80vh;
+    max-height: 800px;
+  }
+  .media-viewer__item img {
+    max-height: 100%;
+    width: auto;
+    height: auto;
+    object-fit: contain;
   }
   .media-thumbs__item {
     flex: 0 0 80px;

--- a/tests/media-gallery.test.js
+++ b/tests/media-gallery.test.js
@@ -15,6 +15,9 @@ assert(Math.abs(paddingPercent(1.5) - 66.6666) < 0.0001);
 const css = fs.readFileSync(path.join(__dirname, '../assets/media-gallery.css'), 'utf8');
 assert(css.includes('border: none'));
 assert(css.includes('--media-gap: var(--space-unit)'));
+assert(css.includes('justify-content: center'));
+assert(css.includes('max-height: 80vh'));
+assert(css.includes('background-color: transparent'));
 
 // Ensure product page media container has no extra margin
 const prodCss = fs.readFileSync(path.join(__dirname, '../assets/product-page.css'), 'utf8');


### PR DESCRIPTION
## Summary
- Center and constrain product image display to remove oversized grey container
- Horizontally center gallery thumbnails beneath main image
- Cover new layout with unit tests

## Testing
- `node tests/media-gallery.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bfef6b6934832684c4169f762e7590