### PR TITLE
Revamp product media gallery layout

### DIFF
--- a/assets/media-gallery.css
+++ b/assets/media-gallery.css
@@ -242,6 +242,24 @@ product-model[loaded] .media-poster {
 @media (min-width: 769px) {
   .media-gallery {
     --media-gap: calc(3 * var(--space-unit));
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+  .media-gallery__viewer {
+    max-width: 800px;
+    max-height: 80vh;
+    margin: 0 auto;
+  }
+  .media-gallery__viewer .media {
+    max-height: 80vh;
+  }
+  .media-gallery__thumbs {
+    width: 100%;
+  }
+  .media-gallery__thumbs .media-thumbs {
+    justify-content: center;
+    gap: var(--space-unit);
   }
   .media--zoom {
     cursor: zoom-in;
@@ -294,18 +312,10 @@ product-model[loaded] .media-poster {
   .product-media--stacked .media--zoom:hover .zoom-image {
     display: block;
   }
-  .media--cover {
-    top: -1px;
-    right: -1px;
-    bottom: -1px;
-    left: -1px;
-    width: auto;
-    height: auto;
-  }
-  .product-media--stacked .media-viewer__item .media::after {
-    content: "";
-    position: absolute;
-    bottom: 0;
+    .product-media--stacked .media-viewer__item .media::after {
+      content: "";
+      position: absolute;
+      bottom: 0;
     left: 0;
     width: 0;
     height: 2px;

--- a/snippets/media-gallery.liquid
+++ b/snippets/media-gallery.liquid
@@ -84,7 +84,7 @@
       data-no-selected-variant="true"
     {% endunless %}
     aria-label="{{ 'products.product.media.gallery_viewer' | t }}"
-    style="--gallery-bg-color:{{ section.settings.bg_color }};--gallery-border-color:{{ section.settings.border_color }};">
+    style="--gallery-bg-color:transparent;--gallery-border-color:transparent;">
   <a class="skip-link btn btn--primary visually-hidden" href="#product-info-{{ section.id }}">
     {{- 'accessibility.skip_to_product_info' | t -}}
   </a>

--- a/snippets/product-media.liquid
+++ b/snippets/product-media.liquid
@@ -126,9 +126,9 @@
         endif
       -%}
 
-      <a href="{{ image_url }}" class="media--cover media--zoom media--zoom-not-loaded inline-flex overflow-hidden absolute top-0 left-0 w-full h-full js-zoom-link" target="_blank">
+      <a href="{{ image_url }}" class="media--zoom media--zoom-not-loaded inline-flex overflow-hidden absolute top-0 left-0 w-full h-full js-zoom-link" target="_blank">
     {%- else -%}
-        <div class="media--cover overflow-hidden absolute top-0 left-0 w-full h-full">
+        <div class="overflow-hidden absolute top-0 left-0 w-full h-full">
     {%- endif -%}
 
     {% render 'image',

--- a/tests/media-gallery.test.js
+++ b/tests/media-gallery.test.js
@@ -15,10 +15,18 @@ assert(Math.abs(paddingPercent(1.5) - 66.6666) < 0.0001);
 const css = fs.readFileSync(path.join(__dirname, '../assets/media-gallery.css'), 'utf8');
 assert(css.includes('border: none'));
 assert(css.includes('--media-gap: var(--space-unit)'));
+assert(css.includes('justify-content: center'));
+assert(css.includes('max-height: 80vh'));
 
 // Ensure product page media container has no extra margin
 const prodCss = fs.readFileSync(path.join(__dirname, '../assets/product-page.css'), 'utf8');
 assert(prodCss.includes('.product-main .product-media {\n  margin-top: 0;'));
+
+// Validate that gallery snippet uses transparent background and no media--cover wrappers
+const gallerySnippet = fs.readFileSync(path.join(__dirname, '../snippets/media-gallery.liquid'), 'utf8');
+assert(gallerySnippet.includes('--gallery-bg-color:transparent'));
+const mediaSnippet = fs.readFileSync(path.join(__dirname, '../snippets/product-media.liquid'), 'utf8');
+assert(!mediaSnippet.includes('media--cover'));
 
 console.log('media-gallery tests passed');
 


### PR DESCRIPTION
## Summary
- Remove grey overlay container and make gallery background transparent
- Center and scale product images with thumbnails below main image
- Add tests ensuring updated gallery styles

## Testing
- `node tests/media-gallery.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68bfef6b6934832684c4169f762e7590