### PR TITLE
Refine product gallery layout

### DIFF
--- a/assets/media-gallery.css
+++ b/assets/media-gallery.css
@@ -37,6 +37,8 @@
 .media-gallery__viewer {
   border: none;
   background-color: transparent;
+  max-width: 800px;
+  margin: 0 auto;
 }
 
 .media-viewer,
@@ -97,7 +99,10 @@
 .media-gallery__thumbs {
   margin-top: var(--media-gap);
 }
-
+.media-thumbs {
+  justify-content: center;
+  gap: var(--space-unit);
+}
 .media-thumbs__item {
   flex: 0 0 84px;
 }

--- a/snippets/media-gallery.liquid
+++ b/snippets/media-gallery.liquid
@@ -84,7 +84,7 @@
       data-no-selected-variant="true"
     {% endunless %}
     aria-label="{{ 'products.product.media.gallery_viewer' | t }}"
-    style="--gallery-bg-color:{{ section.settings.bg_color }};--gallery-border-color:{{ section.settings.border_color }};">
+    style="--gallery-bg-color:transparent;--gallery-border-color:transparent;">
   <a class="skip-link btn btn--primary visually-hidden" href="#product-info-{{ section.id }}">
     {{- 'accessibility.skip_to_product_info' | t -}}
   </a>

--- a/snippets/product-media.liquid
+++ b/snippets/product-media.liquid
@@ -126,9 +126,9 @@
         endif
       -%}
 
-      <a href="{{ image_url }}" class="media--cover media--zoom media--zoom-not-loaded inline-flex overflow-hidden absolute top-0 left-0 w-full h-full js-zoom-link" target="_blank">
+      <a href="{{ image_url }}" class="media--zoom media--zoom-not-loaded inline-flex overflow-hidden absolute top-0 left-0 w-full h-full js-zoom-link" target="_blank">
     {%- else -%}
-        <div class="media--cover overflow-hidden absolute top-0 left-0 w-full h-full">
+        <div class="overflow-hidden absolute top-0 left-0 w-full h-full">
     {%- endif -%}
 
     {% render 'image',

--- a/tests/media-gallery.test.js
+++ b/tests/media-gallery.test.js
@@ -15,6 +15,8 @@ assert(Math.abs(paddingPercent(1.5) - 66.6666) < 0.0001);
 const css = fs.readFileSync(path.join(__dirname, '../assets/media-gallery.css'), 'utf8');
 assert(css.includes('border: none'));
 assert(css.includes('--media-gap: var(--space-unit)'));
+assert(css.includes('max-width: 800px'));
+assert(css.includes('justify-content: center'));
 
 // Ensure product page media container has no extra margin
 const prodCss = fs.readFileSync(path.join(__dirname, '../assets/product-page.css'), 'utf8');


### PR DESCRIPTION
## Summary
- Remove grey backdrop and oversize wrapper from product media gallery
- Constrain main product image width and center thumbnails below
- Update unit test for new gallery styling

## Testing
- `node tests/media-gallery.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bfef6b6934832684c4169f762e7590