### PR TITLE
feat: add smart sticky pair on product page

### DIFF
--- a/assets/product-page.css
+++ b/assets/product-page.css
@@ -135,3 +135,43 @@
 .product-info-card > .product-info__block:last-child {
   margin-bottom: 0;
 }
+
+:root {
+  --sticky-top: var(--header-end, 0);
+}
+
+@media (min-width: 990px) {
+  .pdp-pair {
+    position: relative;
+    display: flex;
+    gap: var(--product-column-padding, 32px);
+  }
+  .pdp-col {
+    position: relative;
+    flex: 1 1 auto;
+  }
+  .pdp-col--info {
+    flex: 0 0 var(--product-info-width);
+  }
+  .pdp-col--info .product-info,
+  .pdp-col--info .product-info__sticky,
+  .pdp-col--info sticky-scroll-direction {
+    position: static;
+    height: 100%;
+  }
+  .pdp-sticky {
+    position: sticky;
+    top: var(--sticky-top);
+  }
+  .pdp-sticky.pdp-locked {
+    position: absolute;
+    top: auto;
+    bottom: 0;
+  }
+}
+
+@media (max-width: 989px) {
+  .pdp-col {
+    height: auto !important;
+  }
+}

--- a/assets/sticky-pair.js
+++ b/assets/sticky-pair.js
@@ -1,0 +1,88 @@
+/**
+ * Smart sticky pair for product page.
+ * The shorter column (gallery or info) sticks while scrolling and
+ * stops at the bottom of the taller column.
+ */
+(function () {
+  const mq = window.matchMedia('(min-width: 990px)');
+  const pair = document.getElementById('pdpPair');
+  if (!pair) return;
+  const galleryCard = document.getElementById('galleryCard');
+  const infoCard = document.getElementById('infoCard');
+  if (!galleryCard || !infoCard) return;
+  const galleryCol = galleryCard.closest('.pdp-col');
+  const infoCol = infoCard.closest('.pdp-col');
+  const cols = [galleryCol, infoCol];
+  let stickyEl = null;
+  let pairHeight = 0;
+  let lockPoint = 0;
+
+  const getTopOffset = () => {
+    const rootStyles = getComputedStyle(document.documentElement);
+    return parseInt(rootStyles.getPropertyValue('--sticky-top')) || 0;
+  };
+
+  const cleanup = () => {
+    window.removeEventListener('scroll', onScroll);
+    stickyEl = null;
+    cols.forEach((col) => (col.style.height = ''));
+    [galleryCard, infoCard].forEach((el) => {
+      el.classList.remove('pdp-sticky', 'pdp-locked');
+      el.style.top = '';
+      el.style.bottom = '';
+      el.style.position = '';
+    });
+  };
+
+  const calculate = () => {
+    cols.forEach((col) => (col.style.height = ''));
+    [galleryCard, infoCard].forEach((el) => {
+      el.classList.remove('pdp-sticky', 'pdp-locked');
+      el.style.top = '';
+      el.style.bottom = '';
+      el.style.position = '';
+    });
+    pairHeight = Math.max(galleryCard.offsetHeight, infoCard.offsetHeight);
+    cols.forEach((col) => (col.style.height = `${pairHeight}px`));
+    stickyEl = galleryCard.offsetHeight < infoCard.offsetHeight ? galleryCard : infoCard;
+    stickyEl.classList.add('pdp-sticky');
+    const topOffset = getTopOffset();
+    const pairRect = pair.getBoundingClientRect();
+    const pairTop = pairRect.top + window.scrollY;
+    lockPoint = pairTop + pairHeight - stickyEl.offsetHeight - topOffset;
+    onScroll();
+  };
+
+  const onScroll = () => {
+    if (!stickyEl) return;
+    if (window.scrollY >= lockPoint) {
+      stickyEl.classList.add('pdp-locked');
+    } else {
+      stickyEl.classList.remove('pdp-locked');
+    }
+  };
+
+  const enable = () => {
+    calculate();
+    window.addEventListener('scroll', onScroll);
+  };
+
+  const check = () => {
+    if (mq.matches) {
+      enable();
+    } else {
+      cleanup();
+    }
+  };
+
+  mq.addEventListener('change', check);
+  window.addEventListener('resize', () => {
+    if (mq.matches) calculate();
+  });
+  const ro = new ResizeObserver(() => {
+    if (mq.matches) calculate();
+  });
+  ro.observe(galleryCard);
+  ro.observe(infoCard);
+  check();
+})();

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -100,36 +100,42 @@
   <script src="{{ 'product-model.js' | asset_url }}" defer></script>
 {%- endif -%}
 
+<script src="{{ 'sticky-pair.js' | asset_url }}" defer></script>
+
 <div class="container">
-  <div class="product js-product" data-section="{{ section.id }}">
+  <div class="pdp-pair" id="pdpPair">
+    <div class="pdp-col pdp-col--gallery">
+      <div id="galleryCard" class="product js-product product-media-card" data-section="{{ section.id }}">
 
-      {%- if product.media.size > 0 -%}
-    {% render 'arktis-gallery', product: product, section: section %}
+        {%- if product.media.size > 0 -%}
+          {% render 'arktis-gallery', product: product, section: section %}
 
 
- 
-      {%- else -%}
-        <div class="media relative">
-          {{ 'image' | placeholder_svg_tag: 'media__placeholder' }}
-        </div>
-      {%- endif -%}
+
+        {%- else -%}
+          <div class="media relative">
+            {{ 'image' | placeholder_svg_tag: 'media__placeholder' }}
+          </div>
+        {%- endif -%}
+      </div>
     </div>
 
-    <div class="product-info{% if section.settings.stick_on_scroll %} product-info--sticky{% endif %}"
-         {% if section.settings.stick_on_scroll %}data-sticky-height-elems="#product-media"{% endif %}>
-      {%- if section.settings.stick_on_scroll -%}
-      <script src="{{ 'sticky-scroll-direction.js' | asset_url }}" defer="defer"></script>
-      <sticky-scroll-direction data-min-sticky-size="md">
-        <div class="product-info__sticky">
-      {%- endif -%}
+    <div class="pdp-col pdp-col--info">
+      <div class="product-info{% if section.settings.stick_on_scroll %} product-info--sticky{% endif %}"
+           {% if section.settings.stick_on_scroll %}data-sticky-height-elems="#product-media"{% endif %}>
+        {%- if section.settings.stick_on_scroll -%}
+        <script src="{{ 'sticky-scroll-direction.js' | asset_url }}" defer="defer"></script>
+        <sticky-scroll-direction data-min-sticky-size="md">
+          <div class="product-info__sticky">
+        {%- endif -%}
 
-      {%- assign has_variant_picker = false -%}
-      {%- if section.settings.sticky_atc_panel -%}
-        <a class="product-options--anchor" id="product-info" rel="nofollow"></a>
-      {%- endif -%}
+        {%- assign has_variant_picker = false -%}
+        {%- if section.settings.sticky_atc_panel -%}
+          <a class="product-options--anchor" id="product-info" rel="nofollow"></a>
+        {%- endif -%}
 
-      <div class="product-info-card">
-      {%- for block in section.blocks -%}
+        <div id="infoCard" class="product-info-card">
+        {%- for block in section.blocks -%}
         {%- case block.type -%}
           {%- when '@app' -%}
             <div class="product-info__block" {{ block.shopify_attributes }}>
@@ -686,11 +692,12 @@
         </div>
       </sticky-scroll-direction>
       {%- endif -%}
+      </div>
     </div>
   </div>
-</div>
+  </div>
 
-{%- render 'product-popups' -%}
+  {%- render 'product-popups' -%}
 
 {%- if section.settings.sticky_atc_panel and product.available -%}
   <link rel="stylesheet" href="{{ 'sticky-atc-panel.css' | asset_url }}" media="print" onload="this.media='all'">


### PR DESCRIPTION
## Summary
- add desktop-only smart sticky pair for gallery and product info cards
- style pair with sticky/locked states using --sticky-top offset
- include JS to choose shorter column, track scroll and lock at bottom

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2598fe0388326bee10b62cf7b6687