### PR TITLE
Ensure gallery and product info stick in sync

### DIFF
--- a/assets/pdp-sticky.js
+++ b/assets/pdp-sticky.js
@@ -1,0 +1,10 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const apply = () => {
+    const top = getComputedStyle(document.documentElement).getPropertyValue('--header-end-padded');
+    document.querySelectorAll('#pdpPair > .pdp-sticky').forEach((el) => {
+      el.style.top = top;
+    });
+  };
+  apply();
+  window.addEventListener('resize', apply);
+});

--- a/assets/product-page.css
+++ b/assets/product-page.css
@@ -64,14 +64,6 @@
     float: right;
     background-color: rgba(var(--bg-color));
   }
-  .product-main .product-info--sticky {
-    min-height: var(--sticky-height, 0);
-  }
-  .product-info__sticky {
-    position: sticky;
-    top: var(--header-end-padded, 48px);
-    padding-bottom: 0;
-  }
   .product-main + .product-details {
     max-width: calc(var(--page-width, 1320px) + var(--gutter) * 2);
     margin: 0 auto;
@@ -107,12 +99,6 @@
   }
 }
 
-@media (min-width: 1024px) {
-  .product-main .product-media {
-    position: sticky;
-    top: var(--header-end-padded, 70px);
-  }
-}
 
 .product-main .product-info {
   background-color: transparent;
@@ -134,4 +120,39 @@
 
 .product-info-card > .product-info__block:last-child {
   margin-bottom: 0;
+}
+
+#pdpPair {
+  display: block;
+}
+#pdpPair > .product-info {
+  float: none;
+  width: 100%;
+  padding: 0;
+}
+
+@media (min-width: 990px) {
+  #pdpPair {
+    display: grid;
+    grid-template-columns: calc(100% - var(--product-info-width)) var(--product-info-width);
+    column-gap: var(--product-column-padding);
+    align-items: start;
+  }
+  #pdpPair > .product,
+  #pdpPair > .product-info {
+    position: sticky;
+    top: var(--header-end-padded);
+  }
+  #pdpPair > .product {
+    padding-top: calc(10 * var(--space-unit));
+    padding-bottom: calc(10 * var(--space-unit));
+    padding-inline-end: var(--product-column-padding);
+  }
+  #pdpPair > .product-info {
+    float: none;
+    width: auto;
+    padding: calc(10 * var(--space-unit)) 0;
+    padding-inline-start: var(--product-column-padding);
+    background-color: rgba(var(--bg-color));
+  }
 }

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -100,8 +100,10 @@
   <script src="{{ 'product-model.js' | asset_url }}" defer></script>
 {%- endif -%}
 
-<div class="container">
-  <div class="product js-product" data-section="{{ section.id }}">
+<script src="{{ 'pdp-sticky.js' | asset_url }}" defer="defer"></script>
+
+<div id="pdpPair" class="container">
+  <div class="product js-product pdp-sticky" data-section="{{ section.id }}">
 
       {%- if product.media.size > 0 -%}
     {% render 'arktis-gallery', product: product, section: section %}
@@ -115,13 +117,7 @@
       {%- endif -%}
     </div>
 
-    <div class="product-info{% if section.settings.stick_on_scroll %} product-info--sticky{% endif %}"
-         {% if section.settings.stick_on_scroll %}data-sticky-height-elems="#product-media"{% endif %}>
-      {%- if section.settings.stick_on_scroll -%}
-      <script src="{{ 'sticky-scroll-direction.js' | asset_url }}" defer="defer"></script>
-      <sticky-scroll-direction data-min-sticky-size="md">
-        <div class="product-info__sticky">
-      {%- endif -%}
+    <div class="product-info pdp-sticky">
 
       {%- assign has_variant_picker = false -%}
       {%- if section.settings.sticky_atc_panel -%}
@@ -682,13 +678,8 @@
      
       </div>
 
-      {%- if section.settings.stick_on_scroll -%}
-        </div>
-      </sticky-scroll-direction>
-      {%- endif -%}
     </div>
   </div>
-</div>
 
 {%- render 'product-popups' -%}
 


### PR DESCRIPTION
## Summary
- Replace float-based product layout with grid `#pdpPair` and make gallery/info columns sticky
- Drop legacy sticky-scroll wrappers and add tiny helper script to sync sticky offset with header

## Testing
- `node tests/media-gallery.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c3aeda109883268f06e2831bab5ecd