### PR TITLE
feat: synchronize product gallery and info scrolling

### DIFF
--- a/assets/product-page.css
+++ b/assets/product-page.css
@@ -135,3 +135,42 @@
 .product-info-card > .product-info__block:last-child {
   margin-bottom: 0;
 }
+
+@media (min-width: 990px) {
+  #pdpPair {
+    display: grid;
+    grid-template-columns: calc(100% - var(--product-info-width)) var(--product-info-width);
+    column-gap: var(--product-column-padding);
+  }
+
+  #pdpPair .product {
+    padding-top: calc(10 * var(--space-unit));
+    padding-bottom: calc(10 * var(--space-unit));
+    padding-right: var(--product-column-padding);
+    position: sticky;
+    top: var(--header-end-padded, 70px);
+    align-self: flex-start;
+  }
+
+  #pdpPair .product-info {
+    padding-top: calc(10 * var(--space-unit));
+    padding-bottom: calc(10 * var(--space-unit));
+    padding-left: var(--product-column-padding);
+    position: sticky;
+    top: var(--header-end-padded, 70px);
+    align-self: flex-start;
+    background-color: rgba(var(--bg-color));
+  }
+}
+
+@media (max-width: 989px) {
+  #pdpPair {
+    display: block;
+  }
+
+  #pdpPair .product,
+  #pdpPair .product-info {
+    padding: 0;
+    position: static;
+  }
+}

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -101,13 +101,11 @@
 {%- endif -%}
 
 <div class="container">
-  <div class="product js-product" data-section="{{ section.id }}">
+  <div id="pdpPair">
+    <div class="product js-product" data-section="{{ section.id }}">
 
       {%- if product.media.size > 0 -%}
-    {% render 'arktis-gallery', product: product, section: section %}
-
-
- 
+        {% render 'arktis-gallery', product: product, section: section %}
       {%- else -%}
         <div class="media relative">
           {{ 'image' | placeholder_svg_tag: 'media__placeholder' }}
@@ -115,14 +113,7 @@
       {%- endif -%}
     </div>
 
-    <div class="product-info{% if section.settings.stick_on_scroll %} product-info--sticky{% endif %}"
-         {% if section.settings.stick_on_scroll %}data-sticky-height-elems="#product-media"{% endif %}>
-      {%- if section.settings.stick_on_scroll -%}
-      <script src="{{ 'sticky-scroll-direction.js' | asset_url }}" defer="defer"></script>
-      <sticky-scroll-direction data-min-sticky-size="md">
-        <div class="product-info__sticky">
-      {%- endif -%}
-
+    <div id="pdpInfo" class="product-info">
       {%- assign has_variant_picker = false -%}
       {%- if section.settings.sticky_atc_panel -%}
         <a class="product-options--anchor" id="product-info" rel="nofollow"></a>
@@ -679,13 +670,8 @@
             {%- endif -%}
         {%- endcase -%}
       {%- endfor -%}
-     
-      </div>
 
-      {%- if section.settings.stick_on_scroll -%}
-        </div>
-      </sticky-scroll-direction>
-      {%- endif -%}
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- wrap product gallery and info sections in `#pdpPair` grid container
- use native CSS sticky to align gallery and product info columns
- remove legacy sticky-scroll-direction script and related wrappers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3aeda109883268f06e2831bab5ecd