### PR TITLE
Sync product gallery and info scrolling

### DIFF
--- a/assets/pdp-sticky.js
+++ b/assets/pdp-sticky.js
@@ -1,0 +1,10 @@
+ document.addEventListener('DOMContentLoaded', () => {
+   const header = document.querySelector('header');
+   const update = () => {
+     const pad = getComputedStyle(document.documentElement).getPropertyValue('--header-end-padded');
+     const top = pad || (header ? `${header.getBoundingClientRect().bottom}px` : '0px');
+     document.documentElement.style.setProperty('--pdp-sticky-top', top.trim());
+   };
+   update();
+   window.addEventListener('resize', update, { passive: true });
+ });

--- a/assets/product-page.css
+++ b/assets/product-page.css
@@ -64,14 +64,6 @@
     float: right;
     background-color: rgba(var(--bg-color));
   }
-  .product-main .product-info--sticky {
-    min-height: var(--sticky-height, 0);
-  }
-  .product-info__sticky {
-    position: sticky;
-    top: var(--header-end-padded, 48px);
-    padding-bottom: 0;
-  }
   .product-main + .product-details {
     max-width: calc(var(--page-width, 1320px) + var(--gutter) * 2);
     margin: 0 auto;
@@ -107,12 +99,6 @@
   }
 }
 
-@media (min-width: 1024px) {
-  .product-main .product-media {
-    position: sticky;
-    top: var(--header-end-padded, 70px);
-  }
-}
 
 .product-main .product-info {
   background-color: transparent;
@@ -134,4 +120,25 @@
 
 .product-info-card > .product-info__block:last-child {
   margin-bottom: 0;
+}
+
+#pdpPair {
+  display: block;
+}
+
+@media (min-width: 990px) {
+  #pdpPair {
+    display: grid;
+    grid-template-columns: calc(100% - var(--product-info-width, 47%)) var(--product-info-width, 47%);
+    column-gap: var(--product-column-padding, 32px);
+    align-items: start;
+  }
+
+  #pdpPair > .product,
+  #pdpPair > .product-info {
+    position: sticky;
+    top: var(--pdp-sticky-top, var(--header-end-padded, 0));
+    align-self: start;
+    height: fit-content;
+  }
 }

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -32,6 +32,7 @@
 {%- endif -%}
 
 <script src="{{ 'product-form.js' | asset_url }}" defer="defer"></script>
+<script src="{{ 'pdp-sticky.js' | asset_url }}" defer="defer"></script>
 
 {%- liquid
   # constants
@@ -101,27 +102,22 @@
 {%- endif -%}
 
 <div class="container">
-  <div class="product js-product" data-section="{{ section.id }}">
+  <div id="pdpPair">
+    <div class="product js-product" data-section="{{ section.id }}">
 
-      {%- if product.media.size > 0 -%}
-    {% render 'arktis-gallery', product: product, section: section %}
+        {%- if product.media.size > 0 -%}
+      {% render 'arktis-gallery', product: product, section: section %}
 
 
- 
-      {%- else -%}
-        <div class="media relative">
-          {{ 'image' | placeholder_svg_tag: 'media__placeholder' }}
-        </div>
-      {%- endif -%}
-    </div>
 
-    <div class="product-info{% if section.settings.stick_on_scroll %} product-info--sticky{% endif %}"
-         {% if section.settings.stick_on_scroll %}data-sticky-height-elems="#product-media"{% endif %}>
-      {%- if section.settings.stick_on_scroll -%}
-      <script src="{{ 'sticky-scroll-direction.js' | asset_url }}" defer="defer"></script>
-      <sticky-scroll-direction data-min-sticky-size="md">
-        <div class="product-info__sticky">
-      {%- endif -%}
+        {%- else -%}
+          <div class="media relative">
+            {{ 'image' | placeholder_svg_tag: 'media__placeholder' }}
+          </div>
+        {%- endif -%}
+      </div>
+
+      <div class="product-info">
 
       {%- assign has_variant_picker = false -%}
       {%- if section.settings.sticky_atc_panel -%}
@@ -681,11 +677,6 @@
       {%- endfor -%}
      
       </div>
-
-      {%- if section.settings.stick_on_scroll -%}
-        </div>
-      </sticky-scroll-direction>
-      {%- endif -%}
     </div>
   </div>
 </div>
@@ -753,13 +744,6 @@
   "name": "Product",
   "class": "cc-main-product product-main",
   "settings": [
-    {
-      "type": "checkbox",
-      "id": "stick_on_scroll",
-      "label": "Stick product info on scroll",
-      "info": "Applies to large screens only.",
-      "default": true
-    },
     {
       "type": "checkbox",
       "id": "select_first_variant",


### PR DESCRIPTION
## Summary
- Align gallery and product info scrolling via unified `#pdpPair` grid wrapper
- Introduce sticky layout rules and lightweight helper script for header offset
- Remove legacy sticky wrappers and schema flag

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3aeda109883268f06e2831bab5ecd