### PR TITLE
Synchronize PDP gallery and info with sticky grid

### DIFF
--- a/assets/product-page.css
+++ b/assets/product-page.css
@@ -64,14 +64,6 @@
     float: right;
     background-color: rgba(var(--bg-color));
   }
-  .product-main .product-info--sticky {
-    min-height: var(--sticky-height, 0);
-  }
-  .product-info__sticky {
-    position: sticky;
-    top: var(--header-end-padded, 48px);
-    padding-bottom: 0;
-  }
   .product-main + .product-details {
     max-width: calc(var(--page-width, 1320px) + var(--gutter) * 2);
     margin: 0 auto;
@@ -107,12 +99,6 @@
   }
 }
 
-@media (min-width: 1024px) {
-  .product-main .product-media {
-    position: sticky;
-    top: var(--header-end-padded, 70px);
-  }
-}
 
 .product-main .product-info {
   background-color: transparent;
@@ -134,4 +120,35 @@
 
 .product-info-card > .product-info__block:last-child {
   margin-bottom: 0;
+}
+
+@media (min-width: 990px) {
+  #pdpPair {
+    display: grid;
+    grid-template-columns: 1fr var(--product-info-width, 47%);
+    column-gap: var(--product-column-padding);
+  }
+
+  #pdpPair > * {
+    align-self: start;
+  }
+
+  #pdpGallery,
+  #pdpInfo {
+    position: sticky;
+    top: var(--header-end-padded, 48px);
+    width: auto;
+    float: none;
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+
+  #pdpGallery {
+    padding-inline-end: var(--product-column-padding);
+  }
+
+  #pdpInfo {
+    padding-inline-start: var(--product-column-padding);
+    background: transparent;
+  }
 }

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -101,13 +101,11 @@
 {%- endif -%}
 
 <div class="container">
-  <div class="product js-product" data-section="{{ section.id }}">
+  <div id="pdpPair">
+    <div id="pdpGallery" class="product js-product" data-section="{{ section.id }}">
 
       {%- if product.media.size > 0 -%}
-    {% render 'arktis-gallery', product: product, section: section %}
-
-
- 
+        {% render 'arktis-gallery', product: product, section: section %}
       {%- else -%}
         <div class="media relative">
           {{ 'image' | placeholder_svg_tag: 'media__placeholder' }}
@@ -115,14 +113,7 @@
       {%- endif -%}
     </div>
 
-    <div class="product-info{% if section.settings.stick_on_scroll %} product-info--sticky{% endif %}"
-         {% if section.settings.stick_on_scroll %}data-sticky-height-elems="#product-media"{% endif %}>
-      {%- if section.settings.stick_on_scroll -%}
-      <script src="{{ 'sticky-scroll-direction.js' | asset_url }}" defer="defer"></script>
-      <sticky-scroll-direction data-min-sticky-size="md">
-        <div class="product-info__sticky">
-      {%- endif -%}
-
+    <div id="pdpInfo" class="product-info">
       {%- assign has_variant_picker = false -%}
       {%- if section.settings.sticky_atc_panel -%}
         <a class="product-options--anchor" id="product-info" rel="nofollow"></a>
@@ -681,11 +672,6 @@
       {%- endfor -%}
      
       </div>
-
-      {%- if section.settings.stick_on_scroll -%}
-        </div>
-      </sticky-scroll-direction>
-      {%- endif -%}
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- wrap product gallery and info in new `#pdpPair` container
- remove JS-based sticky logic and rely on pure CSS grid/sticky
- align gallery and info bottoms while scrolling on desktop

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3aeda109883268f06e2831bab5ecd