### PR TITLE
Enable sticky shorter column on product page

### DIFF
--- a/assets/product-page.css
+++ b/assets/product-page.css
@@ -135,12 +135,16 @@
 
   #pdpGallery,
   #pdpInfo {
-    position: sticky;
-    top: var(--header-end-padded, 48px);
     width: auto;
     float: none;
     padding-top: 0;
     padding-bottom: 0;
+  }
+
+  #pdpGallery.is-sticky,
+  #pdpInfo.is-sticky {
+    position: sticky;
+    top: var(--header-end-padded);
   }
 
   #pdpGallery {

--- a/assets/product-sticky-columns.js
+++ b/assets/product-sticky-columns.js
@@ -1,0 +1,25 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const gallery = document.getElementById('pdpGallery');
+  const info = document.getElementById('pdpInfo');
+  if (!gallery || !info) return;
+
+  function updateSticky() {
+    gallery.classList.remove('is-sticky');
+    info.classList.remove('is-sticky');
+
+    if (window.innerWidth < 990) return;
+
+    const galleryHeight = gallery.offsetHeight;
+    const infoHeight = info.offsetHeight;
+
+    if (galleryHeight <= infoHeight) {
+      gallery.classList.add('is-sticky');
+    } else {
+      info.classList.add('is-sticky');
+    }
+  }
+
+  window.addEventListener('load', updateSticky);
+  window.addEventListener('resize', updateSticky);
+  updateSticky();
+});

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -32,6 +32,7 @@
 {%- endif -%}
 
 <script src="{{ 'product-form.js' | asset_url }}" defer="defer"></script>
+<script src="{{ 'product-sticky-columns.js' | asset_url }}" defer="defer"></script>
 
 {%- liquid
   # constants


### PR DESCRIPTION
## Summary
- apply sticky class to shorter product column with dynamic header offset
- measure gallery and info heights to toggle sticky column

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3b54b1ef083269b8a0595fef190e7